### PR TITLE
Keyboard

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ Some verilog models from Till Harbaum [Spectrum](https://github.com/mist-devel/m
 - Memory snapshot save/load in +D and Multiface.
 - Native TAP with turbo loading. Fast loading for TAP and CSW.
 - Kempston Mouse and Joystick.
+- Sinclair Joystick I
 - Audio in from real [tape device](http://www.atari-forum.com/viewtopic.php?p=298401#p298401)
 
 **Core requires MiST firmware update to build 2016/06/26 or newer!**
@@ -66,6 +67,7 @@ It's useful to switch to maximum speed when you are loading tape in normal mode.
 Kempston mouse has no strict convention which bit (D0 or D1) reflects a main button. After each reset, the first button pressed on mouse (left or right buttons only) will be represented by bit D0 (other button will be represented by bit D1). So, if you are not satisfied by mouse button map, then simply press reset and then press other button first.
 Due to port conflict with Kempston joystick, core uses autodetection. Any mouse activity will switch port to mouse control. Any joystick activity will switch port to joystick control.
 Some games/apps autodetect the mouse. So, move the mouse or click its button before use such games/apps.
+The second D-SUB joystick port works as a Sinclar Joystick 1 (emulates keys 6,7,8,9,0)
 
 ### Snapshots:
 Core supports snapshot functionality of +D. In order to use it, you need to mount IMG or MGT image. ROM includes preloaded G+DOS image, thus you can mount IMG/MGT at any time (even while playing the game). **Note #1**: preloaded G+DOS has been patched to allow disk change on-the-fly. So, if you will load G+DOS from disk, then be careful - it may corrupt previous saves if you will change the disk! **Note #2:** only one disk image can be mounted at any time. Thus make sure if you use game from TRD image, the game won't save anything later to its disk. 

--- a/keyboard.sv
+++ b/keyboard.sv
@@ -45,6 +45,8 @@ module keyboard
 	input             ps2_kbd_clk,
 	input             ps2_kbd_data,
 
+	input       [7:0] joystick_1,
+
 	input      [15:0] addr,
 	output      [4:0] key_data,
 
@@ -65,7 +67,7 @@ assign key_data = (!addr[8]  ? keys[0] : 5'b11111)
                  &(!addr[9]  ? keys[1] : 5'b11111)
                  &(!addr[10] ? keys[2] : 5'b11111)
                  &(!addr[11] ? keys[3] : 5'b11111)
-                 &(!addr[12] ? keys[4] : 5'b11111)
+                 &(!addr[12] ? keys[4] & ~{joystick_1[1:0], joystick_1[2], joystick_1[3], joystick_1[4]} : 5'b11111)
                  &(!addr[13] ? keys[5] : 5'b11111)
                  &(!addr[14] ? keys[6] : 5'b11111)
                  &(!addr[15] ? keys[7] : 5'b11111);

--- a/keyboard.sv
+++ b/keyboard.sv
@@ -108,6 +108,7 @@ always @(negedge clk_sys) begin
 
 		case(code)
 			8'h12 : keys[0][0] <= release_btn; // Left shift (CAPS SHIFT)
+			8'h59 : keys[0][0] <= release_btn; // Right shift (CAPS SHIFT)
 			8'h1a : keys[0][1] <= release_btn; // Z
 			8'h22 : keys[0][2] <= release_btn; // X
 			8'h21 : keys[0][3] <= release_btn; // C

--- a/zxspectrum.sv
+++ b/zxspectrum.sv
@@ -262,7 +262,7 @@ always_comb begin
 		'b00XXXXXXX: cpu_din = ram_dout;
 		'b01XXXXXXX: cpu_din = tape_dout;
 		'b1X01XXXXX: cpu_din = fdd_dout;
-		'b1X001XXXX: cpu_din = mouse_sel ? mouse_data : {2'b00, joystick_0[5:0] | joystick_1[5:0]};
+		'b1X001XXXX: cpu_din = mouse_sel ? mouse_data : {2'b00, joystick_0[5:0]};
 		'b1X0001XXX: cpu_din = {page_scr_copy, 7'b1111111};
 		'b1X000011X: cpu_din = (addr[14] ? sound_data : 8'hFF);
 		'b1X0000101: cpu_din = ulap_dout;
@@ -505,7 +505,7 @@ wire  [7:0] mouse_data;
 mouse mouse( .*, .reset(cold_reset), .addr(addr[10:8]), .sel(), .dout(mouse_data));
 
 always @(posedge clk_sys) begin
-	if(joystick_0[5:0] | joystick_1[5:0]) mouse_sel <= 0;
+	if(joystick_0[5:0]) mouse_sel <= 0;
 	if(~ps2_mouse_clk) mouse_sel <= 1;
 end
 


### PR DESCRIPTION
Just two small patches:
- Why don't use the right shift for caps, also, like on the +keyboards.
- Some games only has Sinclair joy opt, or just redefinable keys, so use the second joy port as a Sinclair one (DK'Tronics had a similar interface, one Kempston, one Sinclair, just it had a bug, the up and down directions were reversed on the Sinclair port).