### PR TITLE
Restore ULA port write prevention during turbo load

### DIFF
--- a/tape.sv
+++ b/tape.sv
@@ -426,7 +426,7 @@ always @(posedge clk_sys) begin
 	if(m1 & ~old_m1) begin
 		if((addr == 'h5ED) & rom_en) stdload <= 1;
 		if((addr == 'h562) & rom_en) {turbo, stdhdr} <= {allow_turbo & available, req_hdr};
-		if((addr >= 'h605) | (addr < 'h53F) | ~rom_en) {turbo, stdhdr, stdload} <= 0;
+		if((addr >= 'h605) | (addr < 'h562) | ~rom_en) {turbo, stdhdr, stdload} <= 0;
 
 		if(tape_ld1 & (addr < 'h5CC)) begin
 			byte_wait <= 1;

--- a/zxspectrum.sv
+++ b/zxspectrum.sv
@@ -413,7 +413,7 @@ reg [2:0] border_color;
 reg       ear_out;
 reg       mic_out;
 
-wire ula_we = ~addr[0] & ~nIORQ & ~nWR & nM1;
+wire ula_we = ~addr[0] & ~(tape_turbo | nIORQ) & ~nWR & nM1;
 always @(posedge clk_sys) begin
 	reg old_we;
 	old_we <= ula_we;


### PR DESCRIPTION
The possible simplest fix. The ROM code which makes the border white, and restores it after the loading is not protected, just the other border effects ops.