### PR TITLE
Some patches

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Some verilog models from Till Harbaum [Spectrum](https://github.com/mist-devel/m
 
 ### Features:
 - Fully functional ZX Spectrum 48K, 128K, +3 and Pentagon 128 with correct CPU and Video timings.
-- Pentagon 512K and Profi 1024K memory interfaces.
+- Pentagon 1024K and Profi 1024K memory interfaces.
 - Turbo 7MHz, 14MHz, 28MHz, 56MHz.
 - ULA+ v1.1 programmable palettes with extended Timex control.
 - Timex HiColor, HiRes modes.
@@ -17,6 +17,7 @@ Some verilog models from Till Harbaum [Spectrum](https://github.com/mist-devel/m
 - Native TAP with turbo loading. Fast loading for TAP and CSW.
 - Kempston Mouse and Joystick.
 - Sinclair Joystick I
+- Turbo-Sound interface (dual YM2149 sound chips)
 - Audio in from real [tape device](http://www.atari-forum.com/viewtopic.php?p=298401#p298401)
 
 **Core requires MiST firmware update to build 2016/06/26 or newer!**
@@ -38,7 +39,7 @@ then issue **RANDOMIZE USR 15616**. Use command **RETURN** to leave TR-DOS.
 **MGT** is G+DOS and MasterDOS (SAM Coupe) image. It's similar to IMG but uses different layout. The main purpose is to transfer data to/from SAM Coupe.
 
 **DSK** +3 disk format. In none- +3 modes, +D tries to mount it, however +3 disk images are not compatible with G+DOS.
-The original +3 disk drive is a single-sided single-destiny drive, but this core supports double-sided double-destiny images, too.
+The original +3 disk drive is a 170K single-sided double-density drive, but this core supports 720K double-sided double-density images, too.
 An empty [DSDD image](https://github.com/sorgelig/ZX_Spectrum-128K_MIST/tree/master/releases/dsdd720k.dsk.gz) is great for saving from Multiface.
 ***Note:*** in +3 mode, both the Beta and the +3 disk drive are supported, but only one image can be mounted, so both cannot be used at the same time.
 
@@ -68,7 +69,7 @@ You can control CPU speed by following keys:
 It's useful to switch to maximum speed when you are loading tape in normal mode. Due to SDRAM speed limitation 28MHz and 56MHz speeds include wait states, so effective CPU speed is lower than nominal.
 
 ### Memory Configurations with extra RAM:
-- **Pentagon 512K** uses bits 6 and 7 in port 7FFD to access additional memory.
+- **Pentagon 1024K** uses bits 5, 6 and 7 in port 7FFD to access additional memory. Port EFFD/bit 2 restores 7FFD/bit 5 original functionality (disable paging).
 - **Profi 1024K** uses bits 0-2 in port DFFD to access additional memory.
 
 ### Mouse and Joystick:

--- a/turbosound.sv
+++ b/turbosound.sv
@@ -1,0 +1,149 @@
+module turbosound
+(
+   input        CLK,		   // Global clock
+	input        CE,        // PSG Clock enable
+   input        RESET,	   // Chip RESET (set all Registers to '0', active high)
+   input        BDIR,	   // Bus Direction (0 - read , 1 - write)
+   input        BC,		   // Bus control
+   input  [7:0] DI,	      // Data In
+   output [7:0] DO,	      // Data Out
+   output [7:0] CHANNEL_A, // PSG Output channel A
+   output [7:0] CHANNEL_B, // PSG Output channel B
+   output [7:0] CHANNEL_C, // PSG Output channel C
+
+   input        SEL,
+   input        MODE,
+
+	input  [7:0] IOA_in,
+	output [7:0] IOA_out,
+
+	input  [7:0] IOB_in,
+	output [7:0] IOB_out
+);
+
+// AY1 selected by default
+reg ay_select = 1'b1;
+
+// Bus control for each AY chips
+wire BC_0;
+wire BC_1;
+
+// Data outputs for each AY chips
+wire [7:0] DO_0;
+wire [7:0] DO_1;
+
+// AY activity signals
+reg [5:0]ay0_active;
+reg [5:0]ay1_active;
+wire ay0_playing;
+//wire ay1_playing;
+
+// AY0 channel output data
+wire [7:0] psg_ch_a_0;
+wire [7:0] psg_ch_b_0;
+wire [7:0] psg_ch_c_0;
+
+// AY1 channel output data
+wire [7:0] psg_ch_a_1;
+wire [7:0] psg_ch_b_1;
+wire [7:0] psg_ch_c_1;
+
+// Mixed channel data
+wire [8:0] sum_ch_a;
+wire [8:0] sum_ch_b;
+wire [8:0] sum_ch_c;
+
+// Mixed channel data (normalized)
+wire [7:0] mix_ch_a;
+wire [7:0] mix_ch_b;
+wire [7:0] mix_ch_c;
+
+always_ff @(posedge CLK or posedge RESET) begin
+	if (RESET == 1'b1) begin
+		// Select AY1 after reset
+		ay_select <= 1'b1;
+	end
+	else if (BDIR && BC && DI[7:1] == 7'b1111111) begin
+		// Select AY0 or AY1 according to lower bit of data register (1111 111N)
+		ay_select <= DI[0];
+	end
+end
+
+ym2149 ym2149_0
+(
+	.CLK(CLK),
+	.CE(CE),
+	.RESET(RESET),
+	.BDIR(BDIR),
+	.BC(BC_0),
+	.DI(DI),
+	.DO(DO_0),
+	.CHANNEL_A(psg_ch_a_0),
+	.CHANNEL_B(psg_ch_b_0),
+	.CHANNEL_C(psg_ch_c_0),
+	.ACTIVE(ay0_active),
+	.SEL(SEL),
+	.MODE(MODE),
+
+	.IOA_in(IOA_in),
+	.IOA_out(IOA_out),
+	.IOB_in(IOB_in),
+	.IOB_out(IOB_out)
+);
+
+// AY1 (Default AY)
+ym2149 ym2149_1
+(
+	.CLK(CLK),
+	.CE(CE),
+	.RESET(RESET),
+	.BDIR(BDIR),
+	.BC(BC_1),
+	.DI(DI),
+	.DO(DO_1),
+	.CHANNEL_A(psg_ch_a_1),
+	.CHANNEL_B(psg_ch_b_1),
+	.CHANNEL_C(psg_ch_c_1),
+	.ACTIVE(ay1_active),
+	.SEL(SEL),
+	.MODE(MODE),
+
+	.IOA_in(IOA_in),
+	.IOA_out(IOA_out),
+	.IOB_in(IOB_in),
+	.IOB_out(IOB_out)
+);
+
+assign BC_0 = ~ay_select & BC;
+assign BC_1 = ay_select & BC;
+assign DO = ay_select ? DO_1 : DO_0;
+
+// AY activity signals
+assign ay0_playing = | ay0_active; // OR reduction (all bits of ay0_active OR'ed with each other)
+//assign ay1_playing = | ay1_active; // OR reduction (all bits of ay1_active OR'ed with each other)
+
+// Mix channel signals from both AY/YM chips (extending to 9 bits width to prevent clipping)
+assign sum_ch_a = { 1'b0, psg_ch_a_1 } + { 1'b0, psg_ch_a_0 };
+assign sum_ch_b = { 1'b0, psg_ch_b_1 } + { 1'b0, psg_ch_b_0 };
+assign sum_ch_c = { 1'b0, psg_ch_c_1 } + { 1'b0, psg_ch_c_0 };
+
+// Fit samples back to 8-bit
+assign mix_ch_a = sum_ch_a[8:1];
+assign mix_ch_b = sum_ch_b[8:1];
+assign mix_ch_c = sum_ch_c[8:1];
+
+
+// Control output channels (Only AY_1 plays if not in TurboSound mode)
+assign CHANNEL_A = ~ay0_playing ? psg_ch_a_1 : mix_ch_a;
+assign CHANNEL_B = ~ay0_playing ? psg_ch_b_1 : mix_ch_b;
+assign CHANNEL_C = ~ay0_playing ? psg_ch_c_1 : mix_ch_c;
+
+//assign CHANNEL_A = mix_ch_a;
+//assign CHANNEL_B = mix_ch_b;
+//assign CHANNEL_C = mix_ch_c;
+//assign CHANNEL_A = (ay1_active & ~ay0_active) ? psg_ch_a_1 : mix_ch_a;
+//assign CHANNEL_B = (ay1_active & ~ay0_active) ? psg_ch_b_1 : mix_ch_b;
+//assign CHANNEL_C = (ay1_active & ~ay0_active) ? psg_ch_c_1 : mix_ch_c;
+
+
+endmodule

--- a/ym2149.sv
+++ b/ym2149.sv
@@ -13,8 +13,9 @@ module ym2149
    output [7:0] CHANNEL_B, // PSG Output channel B
    output [7:0] CHANNEL_C, // PSG Output channel C
 
-   input        SEL,
-   input        MODE,
+   input        SEL,			// MSB of p_divider (N111)
+   input        MODE,		// 1 - AY; 0 - YM volume table
+   output [5:0] ACTIVE,		// Returns non-zero if AY is actively playing something
 
 	input  [7:0] IOA_in,
 	output [7:0] IOA_out,
@@ -26,13 +27,19 @@ module ym2149
 assign     IOA_out = ymreg[14];
 assign     IOB_out = ymreg[15];
 
+// Determine if chip has any output on, based on lower 6 bits of R7 - Mixer Control-I/O Enable register
+// [0:2] - Tone enable, [3:5] - Noise Enable
+// Any bit set means that chip is in use
+assign 	   ACTIVE = ~ymreg[7][5:0];
+
 reg        ena_div;
 reg        ena_div_noise;
-reg [3:0]  addr;
-reg [7:0]  ymreg[16];
+reg [3:0]  addr;				// Register address
+reg [7:0]  ymreg[16];		// Registers array
 reg        env_ena;
 reg [4:0]  env_vol;
 
+// Volume table for AY8910/8912 chips (4 bit, 16 values, logarithmic)
 wire [7:0] volTableAy[16] = 
        '{8'h00, 8'h03, 8'h04, 8'h06, 
 		   8'h0a, 8'h0f, 8'h15, 8'h22, 
@@ -40,6 +47,7 @@ wire [7:0] volTableAy[16] =
 		   8'h90, 8'hb5, 8'hd7, 8'hff
 		 };
 
+// Volume table for YM2149(F) chips (5 bit, 32 values, logarithmic)
 wire [7:0] volTableYm[32] = 
 		'{8'h00, 8'h01, 8'h01, 8'h02, 
 		  8'h02, 8'h03, 8'h03, 8'h04, 
@@ -54,6 +62,7 @@ wire [7:0] volTableYm[32] =
 // Read from AY
 assign DO = dout;
 reg [7:0] dout;
+
 always_comb begin
 	case(addr)
 		 0: dout = ymreg[0];

--- a/zxspectrum.qsf
+++ b/zxspectrum.qsf
@@ -333,6 +333,7 @@ set_global_assignment -name VHDL_FILE t80/T80_ALU.vhd
 set_global_assignment -name VHDL_FILE t80/T80.vhd
 set_global_assignment -name VERILOG_FILE pll.v
 set_global_assignment -name SYSTEMVERILOG_FILE sram.sv
+set_global_assignment -name SYSTEMVERILOG_FILE turbosound.sv
 set_global_assignment -name SYSTEMVERILOG_FILE ym2149.sv
 set_global_assignment -name VERILOG_FILE sigma_delta_dac.v
 set_global_assignment -name SYSTEMVERILOG_FILE tape.sv

--- a/zxspectrum.sv
+++ b/zxspectrum.sv
@@ -473,7 +473,8 @@ wire       psg_enable = addr[0] & addr[15] & ~addr[1];
 wire       psg_we     = psg_enable & ~nIORQ & ~nWR & nM1;
 reg        psg_reset;
 
-ym2149 ym2149
+// Turbosound card (Dual AY/YM chips)
+turbosound turbosound
 (
 	.CLK(clk_sys),
 	.CE(ce_psg),

--- a/zxspectrum.sv
+++ b/zxspectrum.sv
@@ -729,6 +729,7 @@ wire        tape_vin;
 smart_tape tape
 (
 	.*,
+	.reset(reset & ~warm_reset),
 	.ce(ce_cpu),
 
 	.turbo(tape_turbo),


### PR DESCRIPTION
Hi!

Did some patches again:
- I found it a bit annoying the tape was rewound at every reset (I have some old tapes digitized in one big .tap file), so prevent it at warm reset.
- I saw the Turbosound in MiSTer, so I thought it would be a good (and easy) backport (dual AY only).
- And some updates and typo fixes to the README (destiny->density, it looked silly, and was my fault)

Hope you accept them.